### PR TITLE
Check if format string is null

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -12,6 +12,8 @@ int _printf(char *format, ...)
 	char specifier[3];
 	va_list args;
 
+	if (format == NULL)
+		return (-1);
 	specifier[2] = '\0';
 	va_start(args, format);
 	while (format[0])


### PR DESCRIPTION
This pull request contains the work to check if the format string is null. This check was removed when the is_valid_format was removed.