### PR TITLE
Loads characters into buffer before calling write

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -16,6 +16,8 @@ int _printf(char *format, ...)
 		return (-1);
 	specifier[2] = '\0';
 	va_start(args, format);
+	/* initialize the buffer */
+	_putchar(-1);
 	while (format[0])
 	{
 		if (format[0] == '%')
@@ -46,5 +48,7 @@ int _printf(char *format, ...)
 			format++;
 		}
 	}
+	/* print the rest of the buffer */
+	_putchar(-2);
 	return (written);
 }

--- a/_putchar.c
+++ b/_putchar.c
@@ -7,5 +7,25 @@
  */
 int _putchar(char c)
 {
+	static int bufferCount;
+	static char buffer[1024];
+
+	if (c == -1)
+	{
+		bufferCount = 0;
+		return (0);
+	}
+	if (c == -2 || bufferCount == 1024)
+	{
+		write(1, buffer, bufferCount);
+		bufferCount = 0;
+		return (0);
+	}
+	if (c != -1 && c != -2)
+	{
+		buffer[bufferCount] = c;
+		bufferCount++;
+		return(1);
+	}
 	return (write(1, &c, 1));
 }


### PR DESCRIPTION
This pull request contains the work to store characters into a buffer of 1024 bytes in order to call `write()` as little as possible.

_putchar(-1) is used to initialize our bufferCount to 0. bufferCount represents the number of characters in out buffer.

_putchar(-2) is used to write whatever is left in our buffer before we exit the _printf function

any other argument will store the character into the buffer